### PR TITLE
Clarify that console methods need to be bound for use with tap

### DIFF
--- a/API.md
+++ b/API.md
@@ -2209,7 +2209,9 @@ doSomething()
     .then(...)
 ```
 
+*Note: in browsers it is necessary to call `.tap` with `console.log.bind(console)` because console methods can not be called as stand-alone functions.*
 
+<hr>
 
 #####`.call(String propertyName [, dynamic arg...])` -> `Promise`
 


### PR DESCRIPTION
As requested in #547